### PR TITLE
Documentation, inline-hints, `either`, `map_left` and `map_right`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,12 +90,12 @@ impl<L, R> Either<L, R> {
     /// # Examples
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left(123);
+    /// let left: Either<_, ()> = Left(123);
     /// assert_eq!(left.is_left(), true);
     ///
-    /// let right: Either<(), _> = Either::Right("the right value");
+    /// let right: Either<(), _> = Right("the right value");
     /// assert_eq!(right.is_left(), false);
     /// ```
     #[inline]
@@ -111,12 +111,12 @@ impl<L, R> Either<L, R> {
     /// # Examples
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left(123);
+    /// let left: Either<_, ()> = Left(123);
     /// assert_eq!(left.is_right(), false);
     ///
-    /// let right: Either<(), _> = Either::Right("the right value");
+    /// let right: Either<(), _> = Right("the right value");
     /// assert_eq!(right.is_right(), true);
     /// ```
     #[inline]
@@ -129,12 +129,12 @@ impl<L, R> Either<L, R> {
     /// # Examples
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left("some value");
+    /// let left: Either<_, ()> = Left("some value");
     /// assert_eq!(left.left(),  Some("some value"));
     ///
-    /// let right: Either<(), _> = Either::Right(321);
+    /// let right: Either<(), _> = Right(321);
     /// assert_eq!(right.left(), None);
     /// ```
     #[inline]
@@ -150,12 +150,12 @@ impl<L, R> Either<L, R> {
     /// # Examples
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left("some value");
+    /// let left: Either<_, ()> = Left("some value");
     /// assert_eq!(left.right(),  None);
     ///
-    /// let right: Either<(), _> = Either::Right(321);
+    /// let right: Either<(), _> = Right(321);
     /// assert_eq!(right.right(), Some(321));
     /// ```
     #[inline]
@@ -169,13 +169,13 @@ impl<L, R> Either<L, R> {
     /// Converts `Either<L, R>` to `Either<&L, &R>`.
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left("some value");
-    /// assert_eq!(left.as_ref(), Either::Left(&"some value"));
+    /// let left: Either<_, ()> = Left("some value");
+    /// assert_eq!(left.as_ref(), Left(&"some value"));
     ///
-    /// let right: Either<(), _> = Either::Right("some value");
-    /// assert_eq!(right.as_ref(), Either::Right(&"some value"));
+    /// let right: Either<(), _> = Right("some value");
+    /// assert_eq!(right.as_ref(), Right(&"some value"));
     /// ```
     #[inline]
     pub fn as_ref(&self) -> Either<&L, &R> {
@@ -188,22 +188,22 @@ impl<L, R> Either<L, R> {
     /// Converts `Either<L, R>` to `Either<&mut L, &mut R>`.
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
     /// fn mutate(r: &mut Either<u32, u32>) {
     ///     match r.as_mut() {
-    ///         Either::Left(&mut ref mut l) => *l = 314,
-    ///         Either::Right(&mut ref mut r) => *r = 1,
+    ///         Left(&mut ref mut l) => *l = 314,
+    ///         Right(&mut ref mut r) => *r = 1,
     ///     }
     /// }
     ///
-    /// let mut left = Either::Left(123);
+    /// let mut left = Left(123);
     /// mutate(&mut left);
-    /// assert_eq!(left, Either::Left(314));
+    /// assert_eq!(left, Left(314));
     ///
-    /// let mut right = Either::Right(123);
+    /// let mut right = Right(123);
     /// mutate(&mut right);
-    /// assert_eq!(right, Either::Right(1));
+    /// assert_eq!(right, Right(1));
     /// ```
     #[inline]
     pub fn as_mut(&mut self) -> Either<&mut L, &mut R> {
@@ -218,7 +218,7 @@ impl<L, R> Either<L, R> {
     /// # Examples
     ///
     /// ```
-    /// use either::Either;
+    /// use either::*;
     ///
     /// let left: Either<_, ()> = Either::Left(123);
     /// assert_eq!(left.flip(), Either::Right(123));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,17 +220,61 @@ impl<L, R> Either<L, R> {
     /// ```
     /// use either::*;
     ///
-    /// let left: Either<_, ()> = Either::Left(123);
-    /// assert_eq!(left.flip(), Either::Right(123));
+    /// let left: Either<_, ()> = Left(123);
+    /// assert_eq!(left.flip(), Right(123));
     ///
-    /// let right: Either<(), _> = Either::Right("some value");
-    /// assert_eq!(right.flip(), Either::Left("some value"));
+    /// let right: Either<(), _> = Right("some value");
+    /// assert_eq!(right.flip(), Left("some value"));
     /// ```
     #[inline]
     pub fn flip(self) -> Either<R, L> {
         match self {
             Left(l) => Right(l),
             Right(r) => Left(r),
+        }
+    }
+
+    /// Applies the function `f` on the `Left(L)` variant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let left: Either<_, u32> = Left(123);
+    /// assert_eq!(left.map_left(|x| x * 2), Left(246));
+    ///
+    /// let right: Either<u32, _> = Right(123);
+    /// assert_eq!(right.map_left(|x| x * 2), Right(123));
+    /// ```
+    #[inline]
+    pub fn map_left<F, M>(self, f: F) -> Either<M, R>
+        where F: FnOnce(L) -> M {
+        match self {
+            Left(l) => Left(f(l)),
+            Right(r) => Right(r),
+        }
+    }
+
+    /// Applies the function `f` on the `Right(R)` variant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let left: Either<_, u32> = Left(123);
+    /// assert_eq!(left.map_right(|x| x * 2), Left(123));
+    ///
+    /// let right: Either<u32, _> = Right(123);
+    /// assert_eq!(right.map_right(|x| x * 2), Right(246));
+    /// ```
+    #[inline]
+    pub fn map_right<F, S>(self, f: F) -> Either<L, S>
+        where F: FnOnce(R) -> S {
+        match self {
+            Left(l) => Left(l),
+            Right(r) => Right(f(r)),
         }
     }
 
@@ -257,8 +301,8 @@ impl<L, R> Either<L, R> {
       where F: FnOnce(L) -> T,
             G: FnOnce(R) -> T {
         match self {
-            Either::Left(l) => f(l),
-            Either::Right(r) => g(r),
+            Left(l) => f(l),
+            Right(r) => g(r),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right("the right value");
     /// assert_eq!(right.is_left(), false);
     /// ```
-    #[inline]
     pub fn is_left(&self) -> bool {
         match *self {
             Left(_) => true,
@@ -119,7 +118,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right("the right value");
     /// assert_eq!(right.is_right(), true);
     /// ```
-    #[inline]
     pub fn is_right(&self) -> bool {
         !self.is_left()
     }
@@ -137,7 +135,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right(321);
     /// assert_eq!(right.left(), None);
     /// ```
-    #[inline]
     pub fn left(self) -> Option<L> {
         match self {
             Left(l) => Some(l),
@@ -158,7 +155,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right(321);
     /// assert_eq!(right.right(), Some(321));
     /// ```
-    #[inline]
     pub fn right(self) -> Option<R> {
         match self {
             Left(_) => None,
@@ -177,7 +173,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right("some value");
     /// assert_eq!(right.as_ref(), Right(&"some value"));
     /// ```
-    #[inline]
     pub fn as_ref(&self) -> Either<&L, &R> {
         match *self {
             Left(ref inner) => Left(inner),
@@ -205,7 +200,6 @@ impl<L, R> Either<L, R> {
     /// mutate(&mut right);
     /// assert_eq!(right, Right(1));
     /// ```
-    #[inline]
     pub fn as_mut(&mut self) -> Either<&mut L, &mut R> {
         match *self {
             Left(ref mut inner) => Left(inner),
@@ -226,7 +220,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right("some value");
     /// assert_eq!(right.flip(), Left("some value"));
     /// ```
-    #[inline]
     pub fn flip(self) -> Either<R, L> {
         match self {
             Left(l) => Right(l),
@@ -247,7 +240,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<u32, _> = Right(123);
     /// assert_eq!(right.map_left(|x| x * 2), Right(123));
     /// ```
-    #[inline]
     pub fn map_left<F, M>(self, f: F) -> Either<M, R>
         where F: FnOnce(L) -> M {
         match self {
@@ -269,7 +261,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<u32, _> = Right(123);
     /// assert_eq!(right.map_right(|x| x * 2), Right(246));
     /// ```
-    #[inline]
     pub fn map_right<F, S>(self, f: F) -> Either<L, S>
         where F: FnOnce(R) -> S {
         match self {
@@ -296,7 +287,6 @@ impl<L, R> Either<L, R> {
     /// let right: Either<u32, i32> = Right(-4);
     /// assert_eq!(right.either(square, negate), 4);
     /// ```
-    #[inline]
     pub fn either<F, G, T>(self, f: F, g: G) -> T
       where F: FnOnce(L) -> T,
             G: FnOnce(R) -> T {
@@ -309,7 +299,6 @@ impl<L, R> Either<L, R> {
 
 /// Convert from `Result` to `Either` with `Ok => Right` and `Err => Left`.
 impl<L, R> From<Result<R, L>> for Either<L, R> {
-    #[inline]
     fn from(r: Result<R, L>) -> Self {
         match r {
             Err(e) => Left(e),
@@ -320,7 +309,6 @@ impl<L, R> From<Result<R, L>> for Either<L, R> {
 
 /// Convert from `Either` to `Result` with `Right => Ok` and `Left => Err`.
 impl<L, R> Into<Result<R, L>> for Either<L, R> {
-    #[inline]
     fn into(self) -> Result<R, L> {
         match self {
             Left(l) => Err(l),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,34 @@ impl<L, R> Either<L, R> {
             Right(r) => Left(r),
         }
     }
+
+    /// Applies one of two functions depending on contents, unifying their result. If the value is
+    /// `Left(L)` then the first function `f` is applied; if it is `Right(R)` then the second
+    /// function `g` is applied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// fn square(n: u32) -> i32 { (n * n) as i32 }
+    /// fn negate(n: i32) -> i32 { -n }
+    ///
+    /// let left: Either<u32, i32> = Left(4);
+    /// assert_eq!(left.either(square, negate), 16);
+    ///
+    /// let right: Either<u32, i32> = Right(-4);
+    /// assert_eq!(right.either(square, negate), 4);
+    /// ```
+    #[inline]
+    pub fn either<F, G, T>(self, f: F, g: G) -> T
+      where F: FnOnce(L) -> T,
+            G: FnOnce(R) -> T {
+        match self {
+            Either::Left(l) => f(l),
+            Either::Right(r) => g(r),
+        }
+    }
 }
 
 /// Convert from `Result` to `Either` with `Ok => Right` and `Err => Left`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,8 @@ impl<L, R> Either<L, R> {
 
     /// Converts `Either<L, R>` to `Either<&L, &R>`.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use either::*;
     ///
@@ -181,6 +183,8 @@ impl<L, R> Either<L, R> {
     }
 
     /// Converts `Either<L, R>` to `Either<&mut L, &mut R>`.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use either::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right("the right value");
     /// assert_eq!(right.is_left(), false);
     /// ```
+    #[inline]
     pub fn is_left(&self) -> bool {
         match *self {
             Left(_) => true,
@@ -118,6 +119,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right("the right value");
     /// assert_eq!(right.is_right(), true);
     /// ```
+    #[inline]
     pub fn is_right(&self) -> bool {
         !self.is_left()
     }
@@ -135,6 +137,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right(321);
     /// assert_eq!(right.left(), None);
     /// ```
+    #[inline]
     pub fn left(self) -> Option<L> {
         match self {
             Left(l) => Some(l),
@@ -155,6 +158,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right(321);
     /// assert_eq!(right.right(), Some(321));
     /// ```
+    #[inline]
     pub fn right(self) -> Option<R> {
         match self {
             Left(_) => None,
@@ -173,6 +177,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right("some value");
     /// assert_eq!(right.as_ref(), Either::Right(&"some value"));
     /// ```
+    #[inline]
     pub fn as_ref(&self) -> Either<&L, &R> {
         match *self {
             Left(ref inner) => Left(inner),
@@ -200,6 +205,7 @@ impl<L, R> Either<L, R> {
     /// mutate(&mut right);
     /// assert_eq!(right, Either::Right(1));
     /// ```
+    #[inline]
     pub fn as_mut(&mut self) -> Either<&mut L, &mut R> {
         match *self {
             Left(ref mut inner) => Left(inner),
@@ -220,6 +226,7 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Either::Right("some value");
     /// assert_eq!(right.flip(), Either::Left("some value"));
     /// ```
+    #[inline]
     pub fn flip(self) -> Either<R, L> {
         match self {
             Left(l) => Right(l),
@@ -230,6 +237,7 @@ impl<L, R> Either<L, R> {
 
 /// Convert from `Result` to `Either` with `Ok => Right` and `Err => Left`.
 impl<L, R> From<Result<R, L>> for Either<L, R> {
+    #[inline]
     fn from(r: Result<R, L>) -> Self {
         match r {
             Err(e) => Left(e),
@@ -240,6 +248,7 @@ impl<L, R> From<Result<R, L>> for Either<L, R> {
 
 /// Convert from `Either` to `Result` with `Right => Ok` and `Left => Err`.
 impl<L, R> Into<Result<R, L>> for Either<L, R> {
+    #[inline]
     fn into(self) -> Result<R, L> {
         match self {
             Left(l) => Err(l),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@ macro_rules! try_right {
 impl<L, R> Either<L, R> {
     /// Returns true if the value is `Left(L)`.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use either::*;
     ///
@@ -107,8 +105,6 @@ impl<L, R> Either<L, R> {
 
     /// Returns true if the value is `Right(R)`.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use either::*;
     ///
@@ -123,8 +119,6 @@ impl<L, R> Either<L, R> {
     }
 
     /// Converts the left side of `Either<L, R>` to an `Option<L>`.
-    ///
-    /// # Examples
     ///
     /// ```
     /// use either::*;
@@ -144,8 +138,6 @@ impl<L, R> Either<L, R> {
 
     /// Converts the right side of `Either<L, R>` to an `Option<R>`.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use either::*;
     ///
@@ -164,8 +156,6 @@ impl<L, R> Either<L, R> {
 
     /// Converts `Either<L, R>` to `Either<&L, &R>`.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use either::*;
     ///
@@ -183,8 +173,6 @@ impl<L, R> Either<L, R> {
     }
 
     /// Converts `Either<L, R>` to `Either<&mut L, &mut R>`.
-    ///
-    /// # Examples
     ///
     /// ```
     /// use either::*;
@@ -213,8 +201,6 @@ impl<L, R> Either<L, R> {
 
     /// Converts `Either<L, R>` to `Either<R, L>`.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use either::*;
     ///
@@ -232,8 +218,6 @@ impl<L, R> Either<L, R> {
     }
 
     /// Applies the function `f` on the `Left(L)` variant.
-    ///
-    /// # Examples
     ///
     /// ```
     /// use either::*;
@@ -253,8 +237,6 @@ impl<L, R> Either<L, R> {
     }
 
     /// Applies the function `f` on the `Right(R)` variant.
-    ///
-    /// # Examples
     ///
     /// ```
     /// use either::*;
@@ -276,8 +258,6 @@ impl<L, R> Either<L, R> {
     /// Applies one of two functions depending on contents, unifying their result. If the value is
     /// `Left(L)` then the first function `f` is applied; if it is `Right(R)` then the second
     /// function `g` is applied.
-    ///
-    /// # Examples
     ///
     /// ```
     /// use either::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,19 @@ macro_rules! try_right {
 }
 
 impl<L, R> Either<L, R> {
+    /// Returns true if the value is `Left(L)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left(123);
+    /// assert_eq!(left.is_left(), true);
+    ///
+    /// let right: Either<(), _> = Either::Right("the right value");
+    /// assert_eq!(right.is_left(), false);
+    /// ```
     pub fn is_left(&self) -> bool {
         match *self {
             Left(_) => true,
@@ -92,10 +105,36 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Returns true if the value is `Right(R)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left(123);
+    /// assert_eq!(left.is_right(), false);
+    ///
+    /// let right: Either<(), _> = Either::Right("the right value");
+    /// assert_eq!(right.is_right(), true);
+    /// ```
     pub fn is_right(&self) -> bool {
         !self.is_left()
     }
 
+    /// Converts the left side of `Either<L, R>` to an `Option<L>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left("some value");
+    /// assert_eq!(left.left(),  Some("some value"));
+    ///
+    /// let right: Either<(), _> = Either::Right(321);
+    /// assert_eq!(right.left(), None);
+    /// ```
     pub fn left(self) -> Option<L> {
         match self {
             Left(l) => Some(l),
@@ -103,6 +142,19 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Converts the right side of `Either<L, R>` to an `Option<R>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left("some value");
+    /// assert_eq!(left.right(),  None);
+    ///
+    /// let right: Either<(), _> = Either::Right(321);
+    /// assert_eq!(right.right(), Some(321));
+    /// ```
     pub fn right(self) -> Option<R> {
         match self {
             Left(_) => None,
@@ -110,6 +162,17 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Converts `Either<L, R>` to `Either<&L, &R>`.
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left("some value");
+    /// assert_eq!(left.as_ref(), Either::Left(&"some value"));
+    ///
+    /// let right: Either<(), _> = Either::Right("some value");
+    /// assert_eq!(right.as_ref(), Either::Right(&"some value"));
+    /// ```
     pub fn as_ref(&self) -> Either<&L, &R> {
         match *self {
             Left(ref inner) => Left(inner),
@@ -117,6 +180,26 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Converts `Either<L, R>` to `Either<&mut L, &mut R>`.
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// fn mutate(r: &mut Either<u32, u32>) {
+    ///     match r.as_mut() {
+    ///         Either::Left(&mut ref mut l) => *l = 314,
+    ///         Either::Right(&mut ref mut r) => *r = 1,
+    ///     }
+    /// }
+    ///
+    /// let mut left = Either::Left(123);
+    /// mutate(&mut left);
+    /// assert_eq!(left, Either::Left(314));
+    ///
+    /// let mut right = Either::Right(123);
+    /// mutate(&mut right);
+    /// assert_eq!(right, Either::Right(1));
+    /// ```
     pub fn as_mut(&mut self) -> Either<&mut L, &mut R> {
         match *self {
             Left(ref mut inner) => Left(inner),
@@ -124,6 +207,19 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Converts `Either<L, R>` to `Either<R, L>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use either::Either;
+    ///
+    /// let left: Either<_, ()> = Either::Left(123);
+    /// assert_eq!(left.flip(), Either::Right(123));
+    ///
+    /// let right: Either<(), _> = Either::Right("some value");
+    /// assert_eq!(right.flip(), Either::Left("some value"));
+    /// ```
     pub fn flip(self) -> Either<R, L> {
         match self {
             Left(l) => Right(l),


### PR DESCRIPTION
Added documentation for the methods defined on `Either`, and a few more convenience methods to bring it closer to the functionality provided by `Option` and `Result`.