### PR TITLE
and_then_*

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,8 @@ impl<L, R> Either<L, R> {
         }
     }
 
-    /// Apply the function `f` on the value in the `Left` variant if it is present.
+    /// Apply the function `f` on the value in the `Left` variant if it is present rewrapping the
+    /// result in `Left`.
     ///
     /// ```
     /// use either::*;
@@ -236,7 +237,8 @@ impl<L, R> Either<L, R> {
         }
     }
 
-    /// Apply the function `f` on the value in the `Right` variant if it is present.
+    /// Apply the function `f` on the value in the `Right` variant if it is present rewrapping the
+    /// result in `Right`.
     ///
     /// ```
     /// use either::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,46 @@ impl<L, R> Either<L, R> {
             Right(r) => g(r),
         }
     }
+
+    /// Apply the function `f` on the value in the `Left` variant if it is present.
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let left: Either<_, u32> = Left(123);
+    /// assert_eq!(left.and_then_left::<_,()>(|x| Right(x * 2)), Right(246));
+    ///
+    /// let right: Either<u32, _> = Right(123);
+    /// assert_eq!(right.and_then_left(|x| Right::<(), _>(x * 2)), Right(123));
+    /// ```
+    pub fn and_then_left<F, S>(self, f: F) -> Either<S, R>
+        where F: FnOnce(L) -> Either<S, R>
+    {
+        match self {
+            Left(l) => f(l),
+            Right(r) => Right(r),
+        }
+    }
+
+    /// Apply the function `f` on the value in the `Right` variant if it is present.
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let left: Either<_, u32> = Left(123);
+    /// assert_eq!(left.and_then_right(|x| Right(x * 2)), Left(123));
+    ///
+    /// let right: Either<u32, _> = Right(123);
+    /// assert_eq!(right.and_then_right(|x| Right(x * 2)), Right(246));
+    /// ```
+    pub fn and_then_right<F, S>(self, f: F) -> Either<L, S>
+        where F: FnOnce(R) -> Either<L, S>
+    {
+        match self {
+            Left(l) => Left(l),
+            Right(r) => f(r),
+        }
+    }
 }
 
 /// Convert from `Result` to `Either` with `Ok => Right` and `Err => Left`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,12 +290,12 @@ impl<L, R> Either<L, R> {
     /// use either::*;
     ///
     /// let left: Either<_, u32> = Left(123);
-    /// assert_eq!(left.and_then_left::<_,()>(|x| Right(x * 2)), Right(246));
+    /// assert_eq!(left.left_and_then::<_,()>(|x| Right(x * 2)), Right(246));
     ///
     /// let right: Either<u32, _> = Right(123);
-    /// assert_eq!(right.and_then_left(|x| Right::<(), _>(x * 2)), Right(123));
+    /// assert_eq!(right.left_and_then(|x| Right::<(), _>(x * 2)), Right(123));
     /// ```
-    pub fn and_then_left<F, S>(self, f: F) -> Either<S, R>
+    pub fn left_and_then<F, S>(self, f: F) -> Either<S, R>
         where F: FnOnce(L) -> Either<S, R>
     {
         match self {
@@ -310,12 +310,12 @@ impl<L, R> Either<L, R> {
     /// use either::*;
     ///
     /// let left: Either<_, u32> = Left(123);
-    /// assert_eq!(left.and_then_right(|x| Right(x * 2)), Left(123));
+    /// assert_eq!(left.right_and_then(|x| Right(x * 2)), Left(123));
     ///
     /// let right: Either<u32, _> = Right(123);
-    /// assert_eq!(right.and_then_right(|x| Right(x * 2)), Right(246));
+    /// assert_eq!(right.right_and_then(|x| Right(x * 2)), Right(246));
     /// ```
-    pub fn and_then_right<F, S>(self, f: F) -> Either<L, S>
+    pub fn right_and_then<F, S>(self, f: F) -> Either<L, S>
         where F: FnOnce(R) -> Either<L, S>
     {
         match self {


### PR DESCRIPTION
map_* functions always rewrap the result of invoking the provided closure with the corresponding variant. and_then_* functions require the closure to specify the wrapping variant. This allows the closure to change a `Left` into a `Right` or a `Right` into a `Left`.