### PR TITLE
Flatten the implementation of Either::either

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,10 @@ impl<L, R> Either<L, R> {
       where F: FnOnce(L) -> T,
             G: FnOnce(R) -> T
     {
-        self.either_with((), move |(), x| f(x), move |(), x| g(x))
+        match self {
+            Left(l) => f(l),
+            Right(r) => g(r),
+        }
     }
 
     /// Like `either`, but provide some context to whichever of the


### PR DESCRIPTION
Implementing it through `either_with` just makes more work for the
compiler with the extra closures, and provides no real value to us.
A direct `match` is easy enough.