### PR TITLE
Implement `AsRef` and `AsMut` for `str`, `[T]` and some other unsized types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["bluss"]
 
 license = "MIT/Apache-2.0"

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.5.1
+
+  - Add ``AsRef`` and ``AsMut`` implementations for common unsized types:
+    ``str``, ``[T]``, ``CStr``, ``OsStr``, and ``Path``, by @mexus (#29)
+
 - 1.5.0
 
   - Add new methods ``.factor_first()``, ``.factor_second()`` and ``.into_inner()``


### PR DESCRIPTION
As discussed in #28 

I've also made tests to make sure that we are getting what we really want to. On the other hand the functionality and implementation is so simple and straightforward, while the tests are a little bit clumsy (especially for `AsMut<str>`), so I'm hesitating on whether or not we should keep them.