### PR TITLE
Allow deprecated Error::description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -831,6 +831,7 @@ impl<L, R> DerefMut for Either<L, R>
 impl<L, R> Error for Either<L, R>
     where L: Error, R: Error
 {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         either!(*self, ref inner => inner.description())
     }


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Allows deprecated Error::description

Related PR: https://github.com/rust-lang/rust/pull/66919