### PR TITLE
Use Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "either"
 version = "1.5.3"
 authors = ["bluss"]
+edition = "2018"
 
 license = "MIT/Apache-2.0"
 repository = "https://github.com/bluss/either"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,11 +929,14 @@ fn read_write() {
 fn error() {
     let invalid_utf8 = b"\xff";
     let res = || -> Result<_, Either<_, _>> {
-        try!(::std::str::from_utf8(invalid_utf8).map_err(Left));
-        try!("x".parse::<i32>().map_err(Right));
+        ::std::str::from_utf8(invalid_utf8).map_err(Left)?;
+        "x".parse::<i32>().map_err(Right)?;
         Ok(())
     }();
     assert!(res.is_err());
+
+    // TODO: description() is now deprecated, what to do?
+    #[allow(deprecated)]
     res.unwrap_err().description(); // make sure this can be called
 }
 


### PR DESCRIPTION
Changes the Rust edition to Rust 2018, and removes uses of the deprecated try! macro.