### PR TITLE
Add special utitilies for serde untagged repr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 # run builds for all the trains (and more)
 rust:
-  - 1.12.0
   - stable
   - beta
   - nightly
@@ -24,6 +23,11 @@ env:
     - FEATURES="serde"
 
 matrix:
-  exclude:
+  include:
     - rust: 1.12.0
-      env: FEATURES="serde"
+      env: FEATURES=""
+      before_script:
+        - |
+          cargo generate-lockfile &&
+          cargo update -p serde_json --precise 1.0.0 &&
+          cargo update -p serde --precise 1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["use_std"]
 use_std = []
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "=1.0.0"
 
 [package.metadata.release]
 no-dev-version = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ use_std = []
 
 [dev-dependencies]
 serde_json = "=1.0.0"
+serde = "=1.0.0"
 
 [package.metadata.release]
 no-dev-version = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ default = ["use_std"]
 use_std = []
 
 [dev-dependencies]
-serde_json = "=1.0.0"
-serde = "=1.0.0"
+serde_json = "1.0.0"
 
 [package.metadata.release]
 no-dev-version = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 default = ["use_std"]
 use_std = []
 
+[dev-dependencies]
+serde_json = "1.0"
+
 [package.metadata.release]
 no-dev-version = true
 tag-name = "{{version}}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,76 @@ impl<L, R> fmt::Display for Either<L, R>
     }
 }
 
+#[cfg(feature = "serde")]
+pub mod serde_untagged {
+    //! Untagged serialization/deserialization support.
+    //!
+    //! `Either` uses default, externally-tagged representation.
+    //! However, sometimes it is useful to support several alternative types.
+    //! For example, we may have a field which is generally Map<String, i32>
+    //! but in typical cases Vec<String> would suffice, too.
+    //! ```rust
+    //! #[macro_use]
+    //! extern crate serde;
+    //! // or `use serde::{Serialize, Deserialize};` in newer rust versions.
+    //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    //! use std::collections::HashMap;
+    //! 
+    //! #[derive(Serialize, Deserialize, Debug)]
+    //! #[serde(transparent)]
+    //! struct IntOrString {
+    //!     #[serde(with="either::serde_untagged")]
+    //!     inner: either::Either<Vec<String>, HashMap<String, i32>>
+    //! };
+    //! // serialization
+    //! let data = IntOrString {
+    //!     inner: either::Either::Left(vec!["Hello".to_string()])    
+    //! };
+    //! // notice: no tags are emitted.
+    //! assert_eq!(serde_json::to_string(&data)?, r#"["Hello"]"#);
+    //! // deserialization
+    //! let data: IntOrString = serde_json::from_str(
+    //!     r#"{"a": 0, "b": 14}"#   
+    //! )?;
+    //! println!("found {:?}", data);
+    //! # Ok(()) 
+    //! }
+    //! ```
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use super::Either;
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum UEither<L, R> {
+        Left(L),
+        Right(R),
+    }
+
+    pub fn serialize<L, R, S>(this: &Either<L, R>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        L: Serialize,
+        R: Serialize,
+    {
+        let untagged = this.as_ref().either(UEither::Left, UEither::Right);
+        untagged.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, L, R, D>(deserializer: D) -> Result<Either<L, R>, D::Error>
+    where
+        D: Deserializer<'de>,
+        L: Deserialize<'de>,
+        R: Deserialize<'de>,
+    {
+        let untagged: UEither<L, R> = try!(UEither::deserialize(deserializer));
+        match untagged {
+            UEither::Left(left) => Ok(Either::Left(left)),
+            UEither::Right(right) => Ok(Either::Right(right)),
+        }
+    }
+}
+
 #[test]
 fn basic() {
     let mut e = Left(2);

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -1,0 +1,65 @@
+//! Untagged serialization/deserialization support for Either<L, R>.
+//!
+//! `Either` uses default, externally-tagged representation.
+//! However, sometimes it is useful to support several alternative types.
+//! For example, we may have a field which is generally Map<String, i32>
+//! but in typical cases Vec<String> would suffice, too.
+//! ```rust
+//! #[macro_use]
+//! extern crate serde;
+//! // or `use serde::{Serialize, Deserialize};` in newer rust versions.
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::collections::HashMap;
+//!
+//! #[derive(Serialize, Deserialize, Debug)]
+//! #[serde(transparent)]
+//! struct IntOrString {
+//!     #[serde(with="either::serde_untagged")]
+//!     inner: either::Either<Vec<String>, HashMap<String, i32>>
+//! };
+//! // serialization
+//! let data = IntOrString {
+//!     inner: either::Either::Left(vec!["Hello".to_string()])    
+//! };
+//! // notice: no tags are emitted.
+//! assert_eq!(serde_json::to_string(&data)?, r#"["Hello"]"#);
+//! // deserialization
+//! let data: IntOrString = serde_json::from_str(
+//!     r#"{"a": 0, "b": 14}"#   
+//! )?;
+//! println!("found {:?}", data);
+//! # Ok(())
+//! }
+//! ```
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+pub fn serialize<L, R, S>(this: &super::Either<L, R>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    L: Serialize,
+    R: Serialize,
+{
+    let untagged = this.as_ref().either(Either::Left, Either::Right);
+    untagged.serialize(serializer)
+}
+
+pub fn deserialize<'de, L, R, D>(deserializer: D) -> Result<super::Either<L, R>, D::Error>
+where
+    D: Deserializer<'de>,
+    L: Deserialize<'de>,
+    R: Deserialize<'de>,
+{
+    let untagged: Either<L, R> = try!(Either::deserialize(deserializer));
+    match untagged {
+        Either::Left(left) => Ok(super::Either::Left(left)),
+        Either::Right(right) => Ok(super::Either::Right(right)),
+    }
+}

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -1,0 +1,71 @@
+//! Untagged serialization/deserialization support for Option<Either<L, R>>.
+//!
+//! `Either` uses default, externally-tagged representation.
+//! However, sometimes it is useful to support several alternative types.
+//! For example, we may have a field which is generally Map<String, i32>
+//! but in typical cases Vec<String> would suffice, too.
+//! ```rust
+//! #[macro_use]
+//! extern crate serde;
+//! // or `use serde::{Serialize, Deserialize};` in newer rust versions.
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::collections::HashMap;
+//!
+//! #[derive(Serialize, Deserialize, Debug)]
+//! #[serde(transparent)]
+//! struct IntOrString {
+//!     #[serde(with="either::serde_untagged")]
+//!     inner: either::Either<Vec<String>, HashMap<String, i32>>
+//! };
+//! // serialization
+//! let data = IntOrString {
+//!     inner: either::Either::Left(vec!["Hello".to_string()])    
+//! };
+//! // notice: no tags are emitted.
+//! assert_eq!(serde_json::to_string(&data)?, r#"["Hello"]"#);
+//! // deserialization
+//! let data: IntOrString = serde_json::from_str(
+//!     r#"{"a": 0, "b": 14}"#   
+//! )?;
+//! println!("found {:?}", data);
+//! # Ok(())
+//! }
+//! ```
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+pub fn serialize<L, R, S>(
+    this: &Option<super::Either<L, R>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    L: Serialize,
+    R: Serialize,
+{
+    let untagged = this
+        .as_ref()
+        .map(|either| either.as_ref().either(Either::Left, Either::Right));
+    untagged.serialize(serializer)
+}
+
+pub fn deserialize<'de, L, R, D>(deserializer: D) -> Result<Option<super::Either<L, R>>, D::Error>
+where
+    D: Deserializer<'de>,
+    L: Deserialize<'de>,
+    R: Deserialize<'de>,
+{
+    let untagged = try!(Option::<Either<L, R>>::deserialize(deserializer));
+    match untagged {
+        None => Ok(None),
+        Some(Either::Left(left)) => Ok(Some(super::Either::Left(left))),
+        Some(Either::Right(right)) => Ok(Some(super::Either::Right(right))),
+    }
+}

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -14,12 +14,12 @@
 //! #[derive(Serialize, Deserialize, Debug)]
 //! #[serde(transparent)]
 //! struct IntOrString {
-//!     #[serde(with="either::serde_untagged")]
-//!     inner: either::Either<Vec<String>, HashMap<String, i32>>
+//!     #[serde(with="either::serde_untagged_optional")]
+//!     inner: Option<either::Either<Vec<String>, HashMap<String, i32>>>
 //! };
 //! // serialization
 //! let data = IntOrString {
-//!     inner: either::Either::Left(vec!["Hello".to_string()])    
+//!     inner: Some(either::Either::Left(vec!["Hello".to_string()]))   
 //! };
 //! // notice: no tags are emitted.
 //! assert_eq!(serde_json::to_string(&data)?, r#"["Hello"]"#);


### PR DESCRIPTION
Unfortunately, adding serde(untagged) to Either would be breaking change.

This PR instead provides two functions, that can be used in conjunction with serde(with) to achieve quite untagged representation at user choice.