### PR TITLE
Feature: `unwrap_left` `unwrap_right` `expect_left` `expect_right`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["bluss"]
 
 license = "MIT/Apache-2.0"

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.6.1
+
+  - Add new methods ``.expect_left()``, ``.unwrap_left()``,
+    and equivalents on the right, by @spenserblack (#51)
+
 - 1.6.0
 
   - Add new modules ``serde_untagged`` and ``serde_untagged_optional`` to customize
@@ -42,7 +47,7 @@ Recent Changes
 
 - 1.5.2
 
-  - Add new methods ``.left_or()``,  ``.left_or_default()``,  ``.left_or_else()``,
+  - Add new methods ``.left_or()``, ``.left_or_default()``, ``.left_or_else()``,
     and equivalents on the right, by @DCjanus (#36)
 
 - 1.5.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,58 @@ impl<L, R> Either<L, R> {
             Either::Right(r) => r,
         }
     }
+
+    /// Returns the left value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use either::*;
+    /// let left: Either<_, ()> = Left(3);
+    /// assert_eq!(left.unwrap_left(), 3);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// When `Either` is a `Right` value
+    ///
+    /// ```should_panic
+    /// # use either::*;
+    /// let right: Either<(), _> = Right(3);
+    /// right.unwrap_left();
+    /// ```
+    pub fn unwrap_left(self) -> L where R: std::fmt::Debug {
+        match self {
+            Either::Left(l) => l,
+            Either::Right(r) => panic!("called `Either::unwrap_left()` on a `Right` value: {:?}", r),
+        }
+    }
+
+    /// Returns the right value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use either::*;
+    /// let right: Either<(), _> = Right(3);
+    /// assert_eq!(right.unwrap_right(), 3);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// When `Either` is a `Left` value
+    ///
+    /// ```should_panic
+    /// # use either::*;
+    /// let left: Either<_, ()> = Left(3);
+    /// left.unwrap_right();
+    /// ```
+    pub fn unwrap_right(self) -> R where L: std::fmt::Debug {
+        match self {
+            Either::Right(r) => r,
+            Either::Left(l) => panic!("called `Either::unwrap_right()` on a `Left` value: {:?}", l),
+        }
+    }
 }
 
 impl<T, L, R> Either<(T, L), (T, R)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,10 +556,15 @@ impl<L, R> Either<L, R> {
     /// let right: Either<(), _> = Right(3);
     /// right.unwrap_left();
     /// ```
-    pub fn unwrap_left(self) -> L where R: std::fmt::Debug {
+    pub fn unwrap_left(self) -> L
+    where
+        R: std::fmt::Debug,
+    {
         match self {
             Either::Left(l) => l,
-            Either::Right(r) => panic!("called `Either::unwrap_left()` on a `Right` value: {:?}", r),
+            Either::Right(r) => {
+                panic!("called `Either::unwrap_left()` on a `Right` value: {:?}", r)
+            }
         }
     }
 
@@ -582,10 +587,71 @@ impl<L, R> Either<L, R> {
     /// let left: Either<_, ()> = Left(3);
     /// left.unwrap_right();
     /// ```
-    pub fn unwrap_right(self) -> R where L: std::fmt::Debug {
+    pub fn unwrap_right(self) -> R
+    where
+        L: std::fmt::Debug,
+    {
         match self {
             Either::Right(r) => r,
             Either::Left(l) => panic!("called `Either::unwrap_right()` on a `Left` value: {:?}", l),
+        }
+    }
+
+    /// Returns the left value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use either::*;
+    /// let left: Either<_, ()> = Left(3);
+    /// assert_eq!(left.expect_left("value was Right"), 3);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// When `Either` is a `Right` value
+    ///
+    /// ```should_panic
+    /// # use either::*;
+    /// let right: Either<(), _> = Right(3);
+    /// right.expect_left("value was Right");
+    /// ```
+    pub fn expect_left(self, msg: &str) -> L
+    where
+        R: std::fmt::Debug,
+    {
+        match self {
+            Either::Left(l) => l,
+            Either::Right(r) => panic!("{}: {:?}", msg, r),
+        }
+    }
+
+    /// Returns the right value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use either::*;
+    /// let right: Either<(), _> = Right(3);
+    /// assert_eq!(right.expect_right("value was Left"), 3);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// When `Either` is a `Left` value
+    ///
+    /// ```should_panic
+    /// # use either::*;
+    /// let left: Either<_, ()> = Left(3);
+    /// left.expect_right("value was Right");
+    /// ```
+    pub fn expect_right(self, msg: &str) -> R
+    where
+        L: std::fmt::Debug,
+    {
+        match self {
+            Either::Right(r) => r,
+            Either::Left(l) => panic!("{}: {:?}", msg, l),
         }
     }
 }


### PR DESCRIPTION
References:
- [`Result::unwrap`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap)
- [`Result::expect`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect)
- [`Result::unwrap_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_err)
- [`Result::expect_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.expect_err)

Hello :wave: 

While the behavior of `unwrap` and `expect` can be achieved with `x.left().expect("should be left")`, `x.left_or_else(|_| panic!("should be left"))`, or `match`, I was wondering if these methods should be implemented on `Either` directly, since the README says

>Either has methods that are similar to Option and Result

and `unwrap` and `expect` are fairly commonly used on `Option` and `Result` values.

I understand if you would rather not have these methods implemented for a smaller crate, since it's already possible for the behavior to be achieved with the above examples. I didn't see any issues requesting this feature, so I made this PR so it can be documented whether or not these methods should exist in this crate.