### PR TITLE
Added `Either::{into_left, into_right}` behind feature flag `never_type`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 [features]
 default = ["use_std"]
 use_std = []
+never_type = []
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![doc(html_root_url = "https://docs.rs/either/1/")]
 #![cfg_attr(all(not(test), not(feature = "use_std")), no_std)]
+#![cfg_attr(feature = "never_type", feature(never_type))]
+
 #[cfg(all(not(test), not(feature = "use_std")))]
 extern crate core as std;
 
@@ -652,6 +654,46 @@ impl<L, R> Either<L, R> {
         match self {
             Either::Right(r) => r,
             Either::Left(l) => panic!("{}: {:?}", msg, l),
+        }
+    }
+}
+
+#[cfg(feature = "never_type")]
+impl<L> Either<L, !> {
+    /// Returns the left value, but never panics
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(never_type)]
+    /// # use either::*;
+    /// let left: Either<_, !> = Left(3);
+    /// assert_eq!(left.into_left(), 3);
+    /// ```
+    pub fn into_left(self) -> L {
+        match self {
+            Either::Left(l) => l,
+            Either::Right(r) => r,
+        }
+    }
+}
+
+#[cfg(feature = "never_type")]
+impl<R> Either<!, R> {
+    /// Returns the right value, but never panics
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(never_type)]
+    /// # use either::*;
+    /// let right: Either<!, _> = Right(3);
+    /// assert_eq!(right.into_right(), 3);
+    /// ```
+    pub fn into_right(self) -> R {
+        match self {
+            Either::Right(r) => r,
+            Either::Left(l) => l,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,7 +659,10 @@ impl<L, R> Either<L, R> {
 }
 
 #[cfg(feature = "never_type")]
-impl<L> Either<L, !> {
+impl<L, R> Either<L, R>
+where
+    R: Into<!>,
+{
     /// Returns the left value, but never panics
     ///
     /// # Examples
@@ -673,13 +676,16 @@ impl<L> Either<L, !> {
     pub fn into_left(self) -> L {
         match self {
             Either::Left(l) => l,
-            Either::Right(r) => r,
+            Either::Right(r) => r.into(),
         }
     }
 }
 
 #[cfg(feature = "never_type")]
-impl<R> Either<!, R> {
+impl<L, R> Either<L, R>
+where
+    L: Into<!>,
+{
     /// Returns the right value, but never panics
     ///
     /// # Examples
@@ -693,7 +699,7 @@ impl<R> Either<!, R> {
     pub fn into_right(self) -> R {
         match self {
             Either::Right(r) => r,
-            Either::Left(l) => l,
+            Either::Left(l) => l.into(),
         }
     }
 }


### PR DESCRIPTION
References:
- [`Result::into_ok`](https://doc.rust-lang.org/nightly/std/result/enum.Result.html#method.into_ok)
- [`Result::into_err`](https://doc.rust-lang.org/nightly/std/result/enum.Result.html#method.into_err)

Adds mirrors to those methods of `Result` behind a feature flag.

Not sure if any extra care if required aside from the feature flag due to this being nightly only.
Doc tests can be run with `cargo test --features never_type`, but maybe this should be done by travis?
I've never used travis so I didn't touch the `.travis.yml` file yet, however.