### PR TITLE
Implement the io::Seek trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,7 +1138,8 @@ fn seek() {
     }
 
     let mut reader = if use_empty {
-        Left(io::empty())
+        // Empty didn't impl Seek until Rust 1.51
+        Left(io::Cursor::new([]))
     } else {
         Right(io::Cursor::new(&mockdata[..]))
     };
@@ -1149,7 +1150,7 @@ fn seek() {
 
     // the first read should advance the cursor and return the next 16 bytes thus the `ne`
     assert_eq!(reader.read(&mut buf).unwrap(), buf.len());
-    assert_ne!(&buf, &mockdata[..buf.len()]);
+    assert!(&buf != &mockdata[..buf.len()]); // (assert_ne needs Rust 1.13)
 
     // if the seek operation fails it should read 16..31 instead of 0..15
     reader.seek(io::SeekFrom::Start(0)).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use std::ops::DerefMut;
 #[cfg(any(test, feature = "use_std"))]
 use std::error::Error;
 #[cfg(any(test, feature = "use_std"))]
-use std::io::{self, BufRead, Read, Write};
+use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 
 pub use Either::{Left, Right};
 
@@ -900,6 +900,28 @@ where
 
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         for_both!(*self, ref mut inner => inner.read_to_end(buf))
+    }
+}
+
+#[cfg(any(test, feature = "use_std"))]
+/// `Either<L, R>` implements `Seek` if both `L` and `R` do.
+///
+/// Requires crate feature `"use_std"`
+impl<L, R> Seek for Either<L, R>
+where
+    L: Seek,
+    R: Seek,
+{
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        either!(*self, ref mut inner => inner.seek(pos))
+    }
+
+    fn rewind(&mut self) -> io::Result<()> {
+        either!(*self, ref mut inner => inner.rewind())
+    }
+
+    fn stream_position(&mut self) -> io::Result<u64> {
+        either!(*self, ref mut inner => inner.stream_position())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -913,7 +913,7 @@ where
     R: Seek,
 {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        either!(*self, ref mut inner => inner.seek(pos))
+        for_both!(*self, ref mut inner => inner.seek(pos))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -915,14 +915,6 @@ where
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         either!(*self, ref mut inner => inner.seek(pos))
     }
-
-    fn rewind(&mut self) -> io::Result<()> {
-        either!(*self, ref mut inner => inner.rewind())
-    }
-
-    fn stream_position(&mut self) -> io::Result<u64> {
-        either!(*self, ref mut inner => inner.stream_position())
-    }
 }
 
 #[cfg(any(test, feature = "use_std"))]


### PR DESCRIPTION
This pull request implements [the io::Seek trait](https://doc.rust-lang.org/std/io/trait.Seek.html) on Either when `L` and `R` implements it.