### PR TITLE
Add missing specializations on `Iterator` impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -941,9 +941,10 @@ where
         for_both!(*self, ref mut inner => inner.next_back())
     }
 
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        for_both!(*self, ref mut inner => inner.nth_back(n))
-    }
+    // TODO(MSRV): This was stabilized in Rust 1.37
+    // fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+    //     for_both!(*self, ref mut inner => inner.nth_back(n))
+    // }
 
     fn rfold<Acc, G>(self, init: Acc, f: G) -> Acc
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -958,6 +958,9 @@ where
     L: ExactSizeIterator,
     R: ExactSizeIterator<Item = L::Item>,
 {
+    fn len(&self) -> usize {
+        for_both!(*self, ref inner => inner.len())
+    }
 }
 
 #[cfg(any(test, feature = "use_std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,6 +940,17 @@ where
     fn next_back(&mut self) -> Option<Self::Item> {
         for_both!(*self, ref mut inner => inner.next_back())
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        for_both!(*self, ref mut inner => inner.nth_back(n))
+    }
+
+    fn rfold<Acc, G>(self, init: Acc, f: G) -> Acc
+    where
+        G: FnMut(Acc, Self::Item) -> Acc,
+    {
+        for_both!(self, inner => inner.rfold(init, f))
+    }
 }
 
 impl<L, R> ExactSizeIterator for Either<L, R>


### PR DESCRIPTION
Resolves #65

Delegates directly to the inner iterators, as these implementations may be more performant/generate less LLVM IR than the blanket impls:
 - `DoubleEndedIterator::nth_back`
 - `DoubleEndedIterator::rfold`
 - `ExactSizeIterator::len`