### PR TITLE
Override `source` in the Error impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         rust:
+          - 1.31.0  # MSRV
           - stable
           - beta
           - nightly
         features:
           - ""
           - "serde"
-        include:
-          - rust: 1.12.0  # MSRV
-            features: ""
 
     steps:
       - name: Checkout
@@ -34,12 +32,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
-      - name: (1.12.0) Downgrade serde
-        if: ${{ matrix.rust == '1.12.0' }}
+      - name: (1.31.0) Downgrade serde_json
+        if: ${{ matrix.rust == '1.31.0' }}
         run: |
           cargo generate-lockfile
-          cargo update -p serde_json --precise 1.0.0
-          cargo update -p serde --precise 1.0.0
+          cargo update -p serde_json --precise 1.0.39
 
       - name: Build
         uses: actions-rs/cargo@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1059,6 +1059,10 @@ where
     L: Error,
     R: Error,
 {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        for_both!(*self, ref inner => inner.source())
+    }
+
     #[allow(deprecated)]
     fn description(&self) -> &str {
         for_both!(*self, ref inner => inner.description())

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -6,6 +6,7 @@
 //! but in typical cases Vec<String> would suffice, too.
 //!
 //! ```rust
+//! extern crate either;
 //! #[macro_use]
 //! extern crate serde;
 //! // or `use serde::{Serialize, Deserialize};` in newer rust versions.

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -6,6 +6,7 @@
 //! but in typical cases Vec<String> would suffice, too.
 //!
 //! ```rust
+//! extern crate either;
 //! #[macro_use]
 //! extern crate serde;
 //! // or `use serde::{Serialize, Deserialize};` in newer rust versions.


### PR DESCRIPTION
I think this may not work with the current 1.12.0 MSRV but I wanted to open this anyway to start a discussion.

Without the `source` impl, the `Error` impl is not dramatically useful. All "modern" error handling libraries like `anyhow` operate on `source`.

New MSRV would be 1.37 with this change.