### PR TITLE
Override `read_exact` and `write_all`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1092,6 +1092,14 @@ where
     fn consume(&mut self, amt: usize) {
         for_both!(*self, ref mut inner => inner.consume(amt))
     }
+
+    fn read_until(&mut self, byte: u8, buf: &mut std::vec::Vec<u8>) -> io::Result<usize> {
+        for_both!(*self, ref mut inner => inner.read_until(byte, buf))
+    }
+
+    fn read_line(&mut self, buf: &mut std::string::String) -> io::Result<usize> {
+        for_both!(*self, ref mut inner => inner.read_line(buf))
+    }
 }
 
 #[cfg(any(test, feature = "use_std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1119,6 +1119,10 @@ where
         for_both!(*self, ref mut inner => inner.write_all(buf))
     }
 
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        for_both!(*self, ref mut inner => inner.write_fmt(fmt))
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         for_both!(*self, ref mut inner => inner.flush())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1051,6 +1051,10 @@ where
         for_both!(*self, ref mut inner => inner.read(buf))
     }
 
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        for_both!(*self, ref mut inner => inner.read_exact(buf))
+    }
+
     fn read_to_end(&mut self, buf: &mut std::vec::Vec<u8>) -> io::Result<usize> {
         for_both!(*self, ref mut inner => inner.read_to_end(buf))
     }
@@ -1097,6 +1101,10 @@ where
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         for_both!(*self, ref mut inner => inner.write(buf))
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        for_both!(*self, ref mut inner => inner.write_all(buf))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,6 +1058,10 @@ where
     fn read_to_end(&mut self, buf: &mut std::vec::Vec<u8>) -> io::Result<usize> {
         for_both!(*self, ref mut inner => inner.read_to_end(buf))
     }
+
+    fn read_to_string(&mut self, buf: &mut std::string::String) -> io::Result<usize> {
+        for_both!(*self, ref mut inner => inner.read_to_string(buf))
+    }
 }
 
 #[cfg(any(test, feature = "use_std"))]


### PR DESCRIPTION
Some types override these methods to provide optimizations. Using
default implementations would bypass those overrides and lead to worse
performance.

Overriding the methods to delegate implementations directly solves the
problem.