### PR TITLE
Changes Cargo license field to valid SPDX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["bluss"]
 edition = "2018"
 rust-version = "1.36"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bluss/either"
 documentation = "https://docs.rs/either/1/"
 readme = "README-crates.io.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 authors = ["bluss"]
 edition = "2018"
 rust-version = "1.36"

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.8.1
+
+  - Clarified that the multiple licenses are combined with OR.
+
 - 1.8.0
 
   - **MSRV**: ``either`` now requires Rust 1.36 or later.


### PR DESCRIPTION
This change fixes the license field to valid SPDX. 

[Documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) says that SPDX license expressions support AND and OR operators to combine multiple licenses. Previously multiple licenses could be separated with a /, but that usage is deprecated.

It is currently causing dependency reviews to fail like:
<img width="1004" alt="Dependency" src="https://user-images.githubusercontent.com/4755196/214824776-aa434d21-81f6-4469-9b6c-3c33579d408f.png">