### PR TITLE
Add map_either and map_either_with methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: MSRV dependencies
+        if: matrix.rust == '1.36.0'
+        run: |
+          cargo generate-lockfile
+          cargo update -p serde_json --precise 1.0.99
+          cargo update -p serde --precise 1.0.156
+          cargo update -p quote --precise 1.0.30
+          cargo update -p proc-macro2 --precise 1.0.65
+
       - name: Build (no_std)
         run: cargo build --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 authors = ["bluss"]
 edition = "2018"
 rust-version = "1.36"

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.9.0
+
+  - Add new methods ``.map_either()`` and ``.map_either_with()``, by @nasadorian (#82)
+
 - 1.8.1
 
   - Clarified that the multiple licenses are combined with OR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,15 +382,19 @@ impl<L, R> Either<L, R> {
     /// ```
     /// use either::*;
     ///
-    /// let mut acc: Vec<String> = Vec::new();
+    /// let mut sum = 0;
     ///
-    /// let f = |acc: Vec<String>, s: String| acc.push(s);
-    /// let g = |acc: Vec<String>, u: u32| acc.push(u.to_string());
+    /// // Both closures want to update the same value, so pass it as context.
+    /// let mut f = |sum: &mut usize, s: String| { *sum += s.len(); s.to_uppercase() };
+    /// let mut g = |sum: &mut usize, u: usize| { *sum += u; u.to_string() };
     ///
-    /// let values: Vec<Either<String, u32>> = vec![Left("loopy".into()), Right(42)];
+    /// let left: Either<String, usize> = Left("loopy".into());
+    /// assert_eq!(left.map_either_with(&mut sum, &mut f, &mut g), Left("LOOPY".into()));
     ///
-    /// let _ = values.iter().for_each(|e| e.map_either_with(acc, f, g));
-    /// assert_eq!(acc, vec!["loopy".into(), "42".into()]);
+    /// let right: Either<String, usize> = Right(42);
+    /// assert_eq!(right.map_either_with(&mut sum, &mut f, &mut g), Right("42".into()));
+    ///
+    /// assert_eq!(sum, 47);
     /// ```
     pub fn map_either_with<Ctx, F, G, M, S>(self, ctx: Ctx, f: F, g: G) -> Either<M, S>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,61 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    /// Apply the functions `f` and `g` to the `Left` and `Right` variants
+    /// respectively. This is equivalent to
+    /// [bimap](https://hackage.haskell.org/package/bifunctors-5/docs/Data-Bifunctor.html)
+    /// in functional programming.
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let f = |s: String| s.len();
+    /// let g = |u: u8| u.to_string();
+    ///
+    /// let left: Either<String, u8> = Left("loopy".into());
+    /// assert_eq!(left.map_either(f, g), Left(5));
+    ///
+    /// let right: Either<String, u8> = Right(42);
+    /// assert_eq!(right.map_either(f, g), Right("42".into()));
+    /// ```
+    pub fn map_either<F, G, M, S>(self, f: F, g: G) -> Either<M, S>
+    where
+        F: FnOnce(L) -> M,
+        G: FnOnce(R) -> S,
+    {
+        match self {
+            Left(l) => Left(f(l)),
+            Right(r) => Right(g(r)),
+        }
+    }
+
+    /// Similar to [`map_either`], with an added context `ctx` accessible to
+    /// both functions.
+    ///
+    /// ```
+    /// use either::*;
+    ///
+    /// let mut acc: Vec<String> = Vec::new();
+    ///
+    /// let f = |acc: Vec<String>, s: String| acc.push(s);
+    /// let g = |acc: Vec<String>, u: u32| acc.push(u.to_string());
+    ///
+    /// let values: Vec<Either<String, u32>> = vec![Left("loopy".into()), Right(42)];
+    ///
+    /// let _ = values.iter().for_each(|e| e.map_either_with(acc, f, g));
+    /// assert_eq!(acc, vec!["loopy".into(), "42".into()]);
+    /// ```
+    pub fn map_either_with<Ctx, F, G, M, S>(self, ctx: Ctx, f: F, g: G) -> Either<M, S>
+    where
+        F: FnOnce(Ctx, L) -> M,
+        G: FnOnce(Ctx, R) -> S,
+    {
+        match self {
+            Left(l) => Left(f(ctx, l)),
+            Right(r) => Right(g(ctx, r)),
+        }
+    }
+
     /// Apply one of two functions depending on contents, unifying their result. If the value is
     /// `Left(L)` then the first function `f` is applied; if it is `Right(R)` then the second
     /// function `g` is applied.


### PR DESCRIPTION
This PR adds the `map_either` and `map_either_with` variants to the library. Closes #81 