### PR TITLE
Compile serde_derive separately from serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,16 @@ keywords = ["data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_crate = { package = "serde", version = "1.0.186", optional = true }
+serde_derive = { version = "1.0.0", optional = true }
 
 [features]
 default = ["use_std"]
+serde = ["serde_crate", "serde_derive"]
 use_std = []
 
 [dev-dependencies]
+serde_crate = { package = "serde", version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 
 [package.metadata.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,11 @@ pub use crate::Either::{Left, Right};
 /// The `Either` type is symmetric and treats its variants the same way, without
 /// preference.
 /// (For representing success or error, use the regular `Result` enum instead.)
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Either<L, R> {
     /// A value of type `L`.

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -6,11 +6,13 @@
 //! but in typical cases Vec<String> would suffice, too.
 //!
 //! ```rust
+//! # use serde_crate as serde;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use either::Either;
 //! use std::collections::HashMap;
 //!
 //! #[derive(serde::Serialize, serde::Deserialize, Debug)]
+//! # #[serde(crate = "serde")]
 //! #[serde(transparent)]
 //! struct IntOrString {
 //!     #[serde(with = "either::serde_untagged")]
@@ -33,10 +35,12 @@
 //! # }
 //! ```
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_crate::de::{Deserialize, Deserializer};
+use serde_crate::ser::{Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
+#[derive(Serialize, Deserialize)]
+#[serde(crate = "serde_crate", untagged)]
 enum Either<L, R> {
     Left(L),
     Right(R),

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -6,11 +6,13 @@
 //! but in typical cases Vec<String> would suffice, too.
 //!
 //! ```rust
+//! # use serde_crate as serde;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use either::Either;
 //! use std::collections::HashMap;
 //!
 //! #[derive(serde::Serialize, serde::Deserialize, Debug)]
+//! # #[serde(crate = "serde")]
 //! #[serde(transparent)]
 //! struct IntOrString {
 //!     #[serde(with = "either::serde_untagged_optional")]
@@ -33,10 +35,12 @@
 //! # }
 //! ```
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_crate::de::{Deserialize, Deserializer};
+use serde_crate::ser::{Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(crate = "serde_crate", untagged)]
 enum Either<L, R> {
     Left(L),
     Right(R),


### PR DESCRIPTION
When serde's derive feature is used, serde_derive must be compiled before serde can be, as serde with that feature has a serde_derive dependency.

As of serde 1.0.186, this issue can be avoided by adding a separate serde_derive dependency due to the fact that serde 1.0.186 has a never-applicable dependency on serde_derive, which ensures that there is no incompatible version of serde_derive in a program (https://github.com/serde-rs/serde/pull/2588).

Because MSRV being set to 1.36, it's not possible to use the dep: syntax in features, so serde crate needs to be renamed.

This should improve compilation times of programs that use either with its serde feature, provided it doesn't have other crates that use serde with its derive feature.

Fixes #86.